### PR TITLE
Update github actions and add a dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - jzucker2
+    assignees:
+      - jzucker2
+    labels:
+      - github_actions
+  # maintain dependencies for npm project
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    reviewers:
+      - jzucker2
+    assignees:
+      - jzucker2
+    labels:
+      - dependencies
+    allow:
+      # Allow updates for express and related packages
+      - dependency-name: "express"
+      - dependency-name: "body-parser"
+      # custom for this project
+      - dependency-name: "denon-client"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-#          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
+#          cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
       # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,16 +29,20 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+      # https://github.com/docker/build-push-action/issues/498
+      # https://github.com/docker/buildx/issues/834
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: image=moby/buildkit:v0.9.1
       -
         name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: /tmp/.buildx-cache
@@ -71,7 +75,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
       # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
       # https://github.com/docker/build-push-action/issues/252
       # https://github.com/moby/buildkit/issues/1896

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # https://github.com/nodejs/docker-node/issues/1589
-FROM node:14.18.1-alpine3.12
+FROM node:14.18.1-alpine3.12 AS debian_base
 
 # from https://github.com/nodejs/docker-node/pull/367
 RUN apk --no-cache add git
+FROM debian_base AS node_dependencies
 
 WORKDIR /app
 
@@ -22,9 +23,12 @@ COPY yarn.lock yarn.lock
 # for github actions timeouts?
 RUN yarn install --network-timeout 100000
 
+FROM node_dependencies AS source_code
 COPY src/ src/
 
+FROM source_code AS setup_env
 # this needs to match the env var in the app
 EXPOSE 3131
 
+FROM setup_env AS run_server
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14-alpine
+# https://github.com/nodejs/docker-node/issues/1589
+FROM node:14.18.1-alpine3.12
 
 # from https://github.com/nodejs/docker-node/pull/367
 RUN apk --no-cache add git

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "commander": "^3.0.1",
-    "denon-client": "git://github.com/jzucker2/node-denon-client.git#frankenstein",
+    "denon-client": "github:jzucker2/node-denon-client.git#frankenstein",
     "express": "^4.17.1"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-select-cli",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Manipulate video select",
   "main": "server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-select-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Manipulate video select",
   "main": "server.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,9 +75,9 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-"denon-client@git://github.com/jzucker2/node-denon-client.git#frankenstein":
+"denon-client@github:jzucker2/node-denon-client.git#frankenstein":
   version "0.2.4"
-  resolved "git://github.com/jzucker2/node-denon-client.git#7e6e136cd2e12046b76197675f2c75cd97b6c58a"
+  resolved "https://codeload.github.com/jzucker2/node-denon-client/tar.gz/7e6e136cd2e12046b76197675f2c75cd97b6c58a"
   dependencies:
     bluebird "^3.3.4"
     lodash "^4.9.0"


### PR DESCRIPTION
Found other things to fix

https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported

https://github.com/che-incubator/che-workspace-telemetry-client/pull/76/files